### PR TITLE
Scope text security to password fields only

### DIFF
--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -67,4 +67,14 @@
   .separator {
     @apply border-t border-border;
   }
+
+  /* Only mask password fields; allow normal inputs to show text */
+  input,
+  textarea {
+    -webkit-text-security: none;
+  }
+
+  input[type='password'] {
+    -webkit-text-security: disc;
+  }
 }


### PR DESCRIPTION
## Summary
- prevent global masking of text inputs by overriding `-webkit-text-security`
- restrict masking to only password fields so normal inputs show typed characters

## Testing
- `pnpm -F web build`


------
https://chatgpt.com/codex/tasks/task_e_68c7b2ffd1608325b2c2bb113b7b243a