### PR TITLE
feat(server): validate env vars and add cookie secret

### DIFF
--- a/docs/specs/parent-app-spec-v1.2.md
+++ b/docs/specs/parent-app-spec-v1.2.md
@@ -66,6 +66,7 @@ shared/schemas/      Zod validators + shared types
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/thescientist
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=change_me
+COOKIE_SECRET=change_me
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin

--- a/packages/server/env.example
+++ b/packages/server/env.example
@@ -7,6 +7,9 @@ REDIS_URL=redis://localhost:6379
 # JWT
 JWT_SECRET=your-jwt-secret-here
 
+# Cookies
+COOKIE_SECRET=your-cookie-secret-here
+
 # S3/MinIO
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,7 +20,7 @@ const fastify = Fastify({
 
 // Register cookie support
 fastify.register(require('@fastify/cookie'), {
-  secret: env.JWT_SECRET,
+  secret: env.COOKIE_SECRET,
   parseOptions: {}
 });
 


### PR DESCRIPTION
## Summary
- validate server env vars with Zod and clearer errors
- add dedicated COOKIE_SECRET and use it for signed cookies
- document COOKIE_SECRET in env.example and docs

## Testing
- `pnpm --filter @the-scientist/server lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended")*
- `pnpm --filter @the-scientist/server typecheck` *(fails: Parameter implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b1aac7e88325847d6cbcbd0a7c6f