### PR TITLE
feat: add env-based llm config and validation

### DIFF
--- a/packages/server/src/config/env.ts
+++ b/packages/server/src/config/env.ts
@@ -11,6 +11,8 @@ export const env = {
   S3_SECRET_KEY: process.env.S3_SECRET_KEY!,
   S3_BUCKET: process.env.S3_BUCKET!,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_MODEL: process.env.OPENAI_MODEL,
+  OPENAI_TEMPERATURE: process.env.OPENAI_TEMPERATURE,
   UNPAYWALL_EMAIL: process.env.UNPAYWALL_EMAIL!,
   FEATURE_EXPLORER: process.env.FEATURE_EXPLORER === 'true',
   FEATURE_CHAT_REVIEW: process.env.FEATURE_CHAT_REVIEW === 'true',

--- a/packages/server/src/modules/llm/openai.ts
+++ b/packages/server/src/modules/llm/openai.ts
@@ -1,18 +1,46 @@
 import OpenAI from 'openai';
+import { z } from 'zod';
+import { ScreeningProposalSchema } from '@the-scientist/schemas';
 import { LLMProvider, LLMConfig } from './adapter';
 import { env } from '../../config/env';
+
+class LLMResponseError extends Error {
+  constructor(public code: string, message: string, public raw: string) {
+    super(message);
+  }
+}
+
+const ExplorerResponseSchema = z.object({
+  outline: z.array(z.string()).optional(),
+  narrative: z.array(z.object({
+    section: z.string(),
+    text: z.string(),
+    refs: z.array(z.object({
+      doi: z.string().optional(),
+      pmid: z.string().optional()
+    })).optional()
+  })).optional(),
+  refs: z.array(z.object({
+    title: z.string(),
+    doi: z.string().optional(),
+    pmid: z.string().optional(),
+    journal: z.string(),
+    year: z.number().int()
+  })).optional()
+}).strict();
 
 export class OpenAIProvider implements LLMProvider {
   private client: OpenAI;
   private config: LLMConfig;
 
-  constructor() {
+  constructor(config: Partial<LLMConfig> = {}) {
     this.client = new OpenAI({
       apiKey: env.OPENAI_API_KEY
     });
     this.config = {
-      model: 'gpt-5',
-      temperature: 0
+      model: config.model || env.OPENAI_MODEL || 'gpt-5',
+      temperature: config.temperature ?? (env.OPENAI_TEMPERATURE ? parseFloat(env.OPENAI_TEMPERATURE) : 0),
+      maxTokens: config.maxTokens
     };
   }
 
@@ -32,7 +60,18 @@ Do not invent quotes. If none found, set supports:[] and choose ask or better.`;
       response_format: { type: 'json_object' }
     });
 
-    return JSON.parse(response.choices[0].message.content || '{}');
+    const raw = response.choices[0].message.content || '{}';
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch {
+      throw new LLMResponseError('INVALID_JSON', 'Failed to parse JSON response', raw);
+    }
+    const parsed = ScreeningProposalSchema.safeParse(json);
+    if (!parsed.success) {
+      throw new LLMResponseError('INVALID_SHAPE', parsed.error.message, raw);
+    }
+    return parsed.data;
   }
 
   async generateExplorer(profile: any): Promise<any> {
@@ -46,11 +85,22 @@ Do not fabricate identifiers; omit if unknown.`;
       messages: [
         { role: 'user', content: prompt }
       ],
-      temperature: 0.3,
+      temperature: this.config.temperature,
       response_format: { type: 'json_object' }
     });
 
-    return JSON.parse(response.choices[0].message.content || '{}');
+    const raw = response.choices[0].message.content || '{}';
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch {
+      throw new LLMResponseError('INVALID_JSON', 'Failed to parse JSON response', raw);
+    }
+    const parsed = ExplorerResponseSchema.safeParse(json);
+    if (!parsed.success) {
+      throw new LLMResponseError('INVALID_SHAPE', parsed.error.message, raw);
+    }
+    return parsed.data;
   }
 
   async tighten(text: string): Promise<string> {
@@ -59,7 +109,7 @@ Do not fabricate identifiers; omit if unknown.`;
       messages: [
         { role: 'user', content: `Tighten this text without adding new facts: ${text}` }
       ],
-      temperature: 0.1
+      temperature: this.config.temperature
     });
 
     return response.choices[0].message.content || text;


### PR DESCRIPTION
## Summary
- allow OpenAI model and temperature to be provided via environment variables or constructor options
- harden OpenAI provider by catching JSON.parse errors and validating responses with Zod

## Testing
- `pnpm --filter @the-scientist/server lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended")*
- `pnpm --filter @the-scientist/server typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7b1c85cb483258fbbfa98851149da