### PR TITLE
feat: validate env with zod and document openai config

### DIFF
--- a/docs/EXPLORER-ARCHITECTURE.md
+++ b/docs/EXPLORER-ARCHITECTURE.md
@@ -51,7 +51,7 @@ This document explains how the Explorer feature is implemented so contributors c
 
 ## Configuration & Ops
 - Redis required for BullMQ (`REDIS_URL`). Worker start is attempted at server boot; logs a warning if Redis is unavailable (server still runs).
-- OpenAI is optional (`OPENAI_API_KEY`); mock provider is used if missing.
+- OpenAI is optional (`OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_TEMPERATURE`); mock provider is used if missing.
 - PubMed E-utilities are accessed over HTTPS (no key required); failures degrade gracefully to empty refs.
 
 ## Failure Modes & Retries

--- a/docs/specs/parent-app-spec-v1.2.md
+++ b/docs/specs/parent-app-spec-v1.2.md
@@ -47,7 +47,7 @@ shared/schemas/      Zod validators + shared types
 
 **LLM Integration:**
 - OpenAI GPT-5 Thinking (with Tools) via provider interface
-- Mock provider fallback when OPENAI_API_KEY missing
+- Mock provider fallback when OPENAI_API_KEY missing; model and temperature can be configured via OPENAI_MODEL and OPENAI_TEMPERATURE
 - Temperature 0 for screening decisions
 
 **PDF Processing:**
@@ -66,11 +66,14 @@ shared/schemas/      Zod validators + shared types
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/thescientist
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=change_me
+COOKIE_SECRET=change_me_too
 S3_ENDPOINT=http://localhost:9000
 S3_ACCESS_KEY=minioadmin
 S3_SECRET_KEY=minioadmin
 S3_BUCKET=thescientist
 OPENAI_API_KEY= (optional; mock if empty)
+OPENAI_MODEL=
+OPENAI_TEMPERATURE=
 UNPAYWALL_EMAIL=you@example.com
 FEATURE_EXPLORER=true
 

--- a/packages/server/env.example
+++ b/packages/server/env.example
@@ -6,6 +6,7 @@ REDIS_URL=redis://localhost:6379
 
 # JWT
 JWT_SECRET=your-jwt-secret-here
+COOKIE_SECRET=your-cookie-secret-here
 
 # S3/MinIO
 S3_ENDPOINT=http://localhost:9000
@@ -15,6 +16,8 @@ S3_BUCKET=thescientist
 
 # OpenAI
 OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_MODEL=gpt-5
+OPENAI_TEMPERATURE=0
 
 # Unpaywall
 UNPAYWALL_EMAIL=your-email@example.com

--- a/packages/server/src/config/env.ts
+++ b/packages/server/src/config/env.ts
@@ -1,21 +1,30 @@
 import { config } from 'dotenv';
+import { z } from 'zod';
 
 config();
 
-export const env = {
-  DATABASE_URL: process.env.DATABASE_URL!,
-  REDIS_URL: process.env.REDIS_URL!,
-  JWT_SECRET: process.env.JWT_SECRET!,
-  S3_ENDPOINT: process.env.S3_ENDPOINT!,
-  S3_ACCESS_KEY: process.env.S3_ACCESS_KEY!,
-  S3_SECRET_KEY: process.env.S3_SECRET_KEY!,
-  S3_BUCKET: process.env.S3_BUCKET!,
-  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-  OPENAI_MODEL: process.env.OPENAI_MODEL,
-  OPENAI_TEMPERATURE: process.env.OPENAI_TEMPERATURE,
-  UNPAYWALL_EMAIL: process.env.UNPAYWALL_EMAIL!,
-  FEATURE_EXPLORER: process.env.FEATURE_EXPLORER === 'true',
-  FEATURE_CHAT_REVIEW: process.env.FEATURE_CHAT_REVIEW === 'true',
-  PORT: parseInt(process.env.PORT || '3000'),
-  NODE_ENV: process.env.NODE_ENV || 'development'
-};
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  REDIS_URL: z.string().url(),
+  JWT_SECRET: z.string().min(1),
+  COOKIE_SECRET: z.string().min(1),
+  S3_ENDPOINT: z.string().url(),
+  S3_ACCESS_KEY: z.string().min(1),
+  S3_SECRET_KEY: z.string().min(1),
+  S3_BUCKET: z.string().min(1),
+  OPENAI_API_KEY: z.string().optional(),
+  OPENAI_MODEL: z.string().optional(),
+  OPENAI_TEMPERATURE: z.coerce.number().optional(),
+  UNPAYWALL_EMAIL: z.string().email(),
+  FEATURE_EXPLORER: z.preprocess((v) => v === 'true', z.boolean()).default(false),
+  FEATURE_CHAT_REVIEW: z.preprocess((v) => v === 'true', z.boolean()).default(false),
+  PORT: z.coerce.number().default(3000),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+});
+
+const parsed = envSchema.safeParse(process.env);
+if (!parsed.success) {
+  console.error('Invalid environment variables:', parsed.error.flatten().fieldErrors);
+  throw new Error('Invalid environment variables');
+}
+export const env = parsed.data;


### PR DESCRIPTION
## Summary
- replace server env config with Zod schema and runtime validation
- document OPENAI_MODEL and OPENAI_TEMPERATURE in env example and docs

## Testing
- `pnpm --filter @the-scientist/server lint` *(fails: 106 problems)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm --dir packages/web dlx vitest run`
- `pnpm --filter @the-scientist/server typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c07fcd7c8325be1d015175c9ccdd