### PR TITLE
refactor: centralize LLM response parsing

### DIFF
--- a/packages/server/src/modules/llm/errors.ts
+++ b/packages/server/src/modules/llm/errors.ts
@@ -1,0 +1,5 @@
+export class LLMResponseError extends Error {
+  constructor(public code: string, message: string, public raw: string) {
+    super(message);
+  }
+}

--- a/packages/server/src/modules/llm/openai.ts
+++ b/packages/server/src/modules/llm/openai.ts
@@ -2,32 +2,9 @@ import OpenAI from 'openai';
 import { z } from 'zod';
 import { ScreeningProposalSchema } from '@the-scientist/schemas';
 import { LLMProvider, LLMConfig } from './adapter';
+import { ExplorerResponseSchema } from './schemas';
+import { LLMResponseError } from './errors';
 import { env } from '../../config/env';
-
-class LLMResponseError extends Error {
-  constructor(public code: string, message: string, public raw: string) {
-    super(message);
-  }
-}
-
-const ExplorerResponseSchema = z.object({
-  outline: z.array(z.string()).optional(),
-  narrative: z.array(z.object({
-    section: z.string(),
-    text: z.string(),
-    refs: z.array(z.object({
-      doi: z.string().optional(),
-      pmid: z.string().optional()
-    })).optional()
-  })).optional(),
-  refs: z.array(z.object({
-    title: z.string(),
-    doi: z.string().optional(),
-    pmid: z.string().optional(),
-    journal: z.string(),
-    year: z.number().int()
-  })).optional()
-}).strict();
 
 export class OpenAIProvider implements LLMProvider {
   private client: OpenAI;
@@ -42,6 +19,24 @@ export class OpenAIProvider implements LLMProvider {
       temperature: config.temperature ?? (env.OPENAI_TEMPERATURE ? parseFloat(env.OPENAI_TEMPERATURE) : 0),
       maxTokens: config.maxTokens
     };
+  }
+
+  private parseAndValidateResponse<T extends z.ZodTypeAny>(
+    rawContent: string | null | undefined,
+    schema: T
+  ): z.infer<T> {
+    const raw = rawContent ?? '{}';
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch {
+      throw new LLMResponseError('INVALID_JSON', 'Failed to parse JSON response', raw);
+    }
+    const parsed = schema.safeParse(json);
+    if (!parsed.success) {
+      throw new LLMResponseError('INVALID_SHAPE', parsed.error.message, raw);
+    }
+    return parsed.data;
   }
 
   async propose(candidateId: string, parsedText?: string): Promise<any> {
@@ -60,18 +55,10 @@ Do not invent quotes. If none found, set supports:[] and choose ask or better.`;
       response_format: { type: 'json_object' }
     });
 
-    const raw = response.choices[0].message.content || '{}';
-    let json: unknown;
-    try {
-      json = JSON.parse(raw);
-    } catch {
-      throw new LLMResponseError('INVALID_JSON', 'Failed to parse JSON response', raw);
-    }
-    const parsed = ScreeningProposalSchema.safeParse(json);
-    if (!parsed.success) {
-      throw new LLMResponseError('INVALID_SHAPE', parsed.error.message, raw);
-    }
-    return parsed.data;
+    return this.parseAndValidateResponse(
+      response.choices[0].message.content,
+      ScreeningProposalSchema
+    );
   }
 
   async generateExplorer(profile: any): Promise<any> {
@@ -89,18 +76,10 @@ Do not fabricate identifiers; omit if unknown.`;
       response_format: { type: 'json_object' }
     });
 
-    const raw = response.choices[0].message.content || '{}';
-    let json: unknown;
-    try {
-      json = JSON.parse(raw);
-    } catch {
-      throw new LLMResponseError('INVALID_JSON', 'Failed to parse JSON response', raw);
-    }
-    const parsed = ExplorerResponseSchema.safeParse(json);
-    if (!parsed.success) {
-      throw new LLMResponseError('INVALID_SHAPE', parsed.error.message, raw);
-    }
-    return parsed.data;
+    return this.parseAndValidateResponse(
+      response.choices[0].message.content,
+      ExplorerResponseSchema
+    );
   }
 
   async tighten(text: string): Promise<string> {

--- a/packages/server/src/modules/llm/schemas.ts
+++ b/packages/server/src/modules/llm/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const ExplorerResponseSchema = z.object({
+  outline: z.array(z.string()).optional(),
+  narrative: z.array(z.object({
+    section: z.string(),
+    text: z.string(),
+    refs: z.array(z.object({
+      doi: z.string().optional(),
+      pmid: z.string().optional()
+    })).optional()
+  })).optional(),
+  refs: z.array(z.object({
+    title: z.string(),
+    doi: z.string().optional(),
+    pmid: z.string().optional(),
+    journal: z.string(),
+    year: z.number().int()
+  })).optional()
+}).strict();


### PR DESCRIPTION
## Summary
- add reusable `parseAndValidateResponse` helper for LLM JSON outputs
- import `ExplorerResponseSchema` and `LLMResponseError` and reuse across methods
- refactor proposal and explorer generation to use shared parser

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c06742a08325a416cf5bb14cfe24