### PR TITLE
refactor: simplify OpenAI config fallbacks

### DIFF
--- a/packages/server/src/modules/llm/openai.ts
+++ b/packages/server/src/modules/llm/openai.ts
@@ -15,8 +15,8 @@ export class OpenAIProvider implements LLMProvider {
       apiKey: env.OPENAI_API_KEY
     });
     this.config = {
-      model: config.model || env.OPENAI_MODEL || 'gpt-5',
-      temperature: config.temperature ?? (env.OPENAI_TEMPERATURE ? parseFloat(env.OPENAI_TEMPERATURE) : 0),
+      model: config.model ?? env.OPENAI_MODEL ?? 'gpt-5',
+      temperature: config.temperature ?? env.OPENAI_TEMPERATURE ?? 0,
       maxTokens: config.maxTokens
     };
   }


### PR DESCRIPTION
## Summary
- simplify temperature config for OpenAI provider by using nullish coalescing to fall back to env value or default
- apply nullish coalescing to OpenAI model config for consistent fallback behavior

## Testing
- `pnpm --filter @the-scientist/server lint` *(fails: existing lint errors)*
- `pnpm --filter @the-scientist/server typecheck` *(fails: existing type errors)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c4d65ca8832590347a903f4a6446