### PR TITLE
chore: update OpenAI default model

### DIFF
--- a/packages/server/src/modules/llm/openai.ts
+++ b/packages/server/src/modules/llm/openai.ts
@@ -15,8 +15,8 @@ export class OpenAIProvider implements LLMProvider {
       apiKey: env.OPENAI_API_KEY
     });
     this.config = {
-      model: config.model || env.OPENAI_MODEL || 'gpt-5',
-      temperature: config.temperature ?? (env.OPENAI_TEMPERATURE ? parseFloat(env.OPENAI_TEMPERATURE) : 0),
+      model: config.model || env.OPENAI_MODEL || 'gpt-4o-mini',
+      temperature: config.temperature ?? (env.OPENAI_TEMPERATURE ?? 0),
       maxTokens: config.maxTokens
     };
   }


### PR DESCRIPTION
## Summary
- default to `gpt-4o-mini` for OpenAI interactions
- rely on numeric env var for temperature when configuring client

## Testing
- `pnpm --filter @the-scientist/server lint` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*
- `pnpm --filter @the-scientist/server typecheck` *(fails: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL)*
- `pnpm --filter @the-scientist/server test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c6ee6f388325990bc1d02a0ed289