### PR TITLE
Use dedicated cookie secret

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,7 +20,7 @@ const fastify = Fastify({
 
 // Register cookie support
 fastify.register(require('@fastify/cookie'), {
-  secret: env.JWT_SECRET,
+  secret: env.COOKIE_SECRET,
   parseOptions: {}
 });
 


### PR DESCRIPTION
## Summary
- use `env.COOKIE_SECRET` when registering `@fastify/cookie`
- confirm no other modules use `JWT_SECRET` for cookie signing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c6ece96083259852e8133aa2073a